### PR TITLE
CMake build. Add support for palette expansion.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,28 @@
+set(CommonFiles
+    "common/cli.c"
+    "common/endian-util.c"
+    "common/image.c"
+    "common/io.c"
+    "common/list.c"
+    "common/mem.c"
+    "common/pcx.c"
+    "common/tga.c"
+    "common/wal.c"
+    )
+
+add_executable("wal-convert"
+    "src/wal-convert.c"
+    ${CommonFiles})
+add_executable("wal-edit"
+    "src/wal-edit.c"
+    ${CommonFiles})
+add_executable("wal-export"
+    "src/wal-export.c"
+    ${CommonFiles})
+add_executable("wal-info"
+    "src/wal-info.c"
+    ${CommonFiles})
+add_executable("wal-term"
+    "src/wal-term.c"
+    ${CommonFiles})
+

--- a/common/image.h
+++ b/common/image.h
@@ -29,6 +29,7 @@ typedef struct image_data {
 	uint32_t height;
 	void *header; /* pointer to original header struct */
 	void *userdata;
+	int	alpha_pixels; /* has alpha pixels */
 } image_data_t;
 
 void flip_bgr(sptr_t colors);

--- a/common/tga.c
+++ b/common/tga.c
@@ -15,58 +15,124 @@ static int is_supported(struct image_data image)
 	return 1;
 }
 
-size_t tga_estimate_size(struct image_data image)
+size_t tga_estimate_size(struct image_data image, int expand)
 {
 	if (!is_supported(image)) {
 		return 0;
 	}
-	return TGA_HEADER_SIZE + image.pixels.size + 768;
+	if (expand) {
+		return TGA_HEADER_SIZE + image.pixels.size * ( image.alpha_pixels ? 4 : 3 );
+	} else {
+		return TGA_HEADER_SIZE + image.pixels.size + 768;
+	}
 }
 
-static sptr_t tga_write_header(sptr_t buf, struct image_data image)
+static sptr_t tga_write_header(sptr_t buf, struct image_data image, int expand)
 {
 	(void)image;
 	// TODO: replace with endian_util.h/write_8
 	unsigned char *p = buf.ptr;
 	*p = 0;
 	p++;
-	*p = TGA_COLOR_MAP_PRESENT;
+	*p = expand ? TGA_COLOR_MAP_NONE : TGA_COLOR_MAP_PRESENT;
 	p++;
-	*p = TGA_IMAGE_TYPE_UNCOMPRESSED_COLOR_MAPPED;
-	p++;
-
-	write_le16(0, &p);
-	write_le16(256, &p);
-	*p = 24;
+	*p = expand ? TGA_IMAGE_TYPE_UNCOMPRESSED_TRUE_COLOR : TGA_IMAGE_TYPE_UNCOMPRESSED_COLOR_MAPPED;
 	p++;
 
-	write_le16(0, &p);
-	write_le16(0, &p);
+	write_le16(0, &p); // color map origin
+	write_le16(expand ? 0 : 256, &p); // color map length
+	*p = expand ? 0 : 24; // color map depth
+	p++;
+
+	write_le16(0, &p); // x origin
+	write_le16(0, &p); // y origin
 	write_le16(image.width, &p);
 	write_le16(image.height, &p);
-	*p = 8;
+	*p = expand ? ( image.alpha_pixels ? 32 : 24 ) : 8; // bits per pixel
 	p++;
 	*p = TGA_IM_DESCRIPTOR(TGA_IMAGE_ORIGIN_TOP_LEFT, 0);
 	p++;
 	return (sptr_t){buf.ptr + TGA_HEADER_SIZE, (buf.size - TGA_HEADER_SIZE)};
 }
 
-sptr_t tga_write(sptr_t buf, struct image_data image)
+sptr_t tga_write(sptr_t buf, struct image_data image, int expand)
 {
-	size_t size = tga_estimate_size(image);
+	size_t size = tga_estimate_size(image, expand);
 	if (size == 0 || buf.size < size) {
 		return SPTR_NULL;
 	}
 	memset(buf.ptr, 0, buf.size);
-	sptr_t cm_offset = tga_write_header(buf, image);
-	/* copy palette data */
-	memcpy(cm_offset.ptr, image.palette.data.ptr, image.palette.data.size);
-	/* flip from RGB to BGR in place */
-	sptr_t cm_palette = sptr_slice(cm_offset, 0, image.palette.data.size);
-	flip_bgr(cm_palette);
-	/* copy pixel data */
-	memcpy(cm_offset.ptr + image.palette.data.size, image.pixels.ptr,
-		   image.pixels.size);
+	sptr_t cm_offset = tga_write_header(buf, image, expand);
+	if (!expand)
+	{
+		/* copy palette data */
+		memcpy(cm_offset.ptr, image.palette.data.ptr, image.palette.data.size);
+		/* flip from RGB to BGR in place */
+		sptr_t cm_palette = sptr_slice(cm_offset, 0, image.palette.data.size);
+		flip_bgr(cm_palette);
+		/* copy pixel data */
+		memcpy(cm_offset.ptr + image.palette.data.size, image.pixels.ptr,
+			image.pixels.size);
+	}
+	else
+	{
+		unsigned char *buf = cm_offset.ptr;
+		int num_pixels = image.pixels.size;
+		if (image.alpha_pixels)
+		{
+			/* write BGRA */
+			for (int i = 0; i < num_pixels; i++)
+			{
+				int j = image.pixels.ptr[i];
+
+				if (j == 255)
+				{
+					// transparent, so scan around for another color
+				    // to avoid alpha fringes
+				    // FIXME: do a full flood fill so mips work...
+					/*
+				    if (i > image.width && image.pixels.ptr[i-image.width] != 255)
+					    j = image.pixels.ptr[i-image.width];
+				    else if (i < num_pixels-image.width && image.pixels.ptr[i+image.width] != 255)
+					    j = image.pixels.ptr[i+image.width];
+				    else if (i > 0 && image.pixels.ptr[i-1] != 255)
+					    j = image.pixels.ptr[i-1];
+				    else if (i < num_pixels-1 && image.pixels.ptr[i+1] != 255)
+					    j = image.pixels.ptr[i+1];
+				    else
+					    j = 0;
+
+					buf[i * 4 + 0] = image.palette.data.ptr[j * 3 + 2];
+					buf[i * 4 + 1] = image.palette.data.ptr[j * 3 + 1];
+					buf[i * 4 + 2] = image.palette.data.ptr[j * 3 + 0];
+					*/
+					buf[i * 4 + 0] = 0;
+					buf[i * 4 + 1] = 0;
+					buf[i * 4 + 2] = 0;
+					buf[i * 4 + 3] = 0;
+				}
+				else
+				{
+					buf[i * 4 + 0] = image.palette.data.ptr[j * 3 + 2];
+					buf[i * 4 + 1] = image.palette.data.ptr[j * 3 + 1];
+					buf[i * 4 + 2] = image.palette.data.ptr[j * 3 + 0];
+					buf[i * 4 + 3] = 255;
+				}
+			}
+		}
+		else
+		{
+			/* write BGR */
+			for (int i = 0; i < num_pixels; i++)
+			{
+				int j = image.pixels.ptr[i] * 3;
+
+				buf[i * 3 + 0] = image.palette.data.ptr[j + 2];
+				buf[i * 3 + 1] = image.palette.data.ptr[j + 1];
+				buf[i * 3 + 2] = image.palette.data.ptr[j + 0];
+			}
+		}
+	}
 	return buf;
 }
 

--- a/common/tga.h
+++ b/common/tga.h
@@ -48,8 +48,8 @@ struct tga_header {
 
 #define TGA_HEADER_SIZE 18
 
-size_t tga_estimate_size(struct image_data image);
-sptr_t tga_write(sptr_t buf, const struct image_data image);
+size_t tga_estimate_size(struct image_data image, int expand);
+sptr_t tga_write(sptr_t buf, const struct image_data image, int expand);
 struct image_data *tga_read(const sptr_t data);
 
 #endif /* _TGA_H */

--- a/common/wal.c
+++ b/common/wal.c
@@ -145,6 +145,15 @@ static struct ll_node *wal_dk_read(const sptr_t data, const sptr_t palette)
 		}
 		sptr_t copy = {xmalloc(p.size), p.size};
 		memcpy(copy.ptr, p.ptr, p.size);
+		int alpha_pixels = 0;
+		for (int j = 0; j < p.size; j++)
+		{
+			if (copy.ptr[j] == 255)
+			{
+				alpha_pixels = 1;
+				break;
+			}
+		}
 
 		struct image_palette p_data = {pal, PALETTE_TYPE_RGB_256};
 		uint32_t width = header->width / divisor;
@@ -156,7 +165,7 @@ static struct ll_node *wal_dk_read(const sptr_t data, const sptr_t palette)
 			height = 1;
 		}
 		struct image_data i_data = {
-			copy, p_data, IMAGE_TYPE_WAL_DK, width, height, header, NULL};
+			copy, p_data, IMAGE_TYPE_WAL_DK, width, height, header, NULL, alpha_pixels};
 		mips[i] = i_data;
 		expected_len /= 4;
 		if (expected_len <= 0) {

--- a/tests/tga-test.c
+++ b/tests/tga-test.c
@@ -32,7 +32,7 @@ void test_export_from_q2(void **state)
 	for (i = 0; i < MIP_LEVELS_Q2; i++) {
 		memset(&fname_buf[0], 0, 256);
 		sprintf(&fname_buf[0], "out.test_export_from_q2-mip-%d.tga%c", i, '\0');
-		size_t size = tga_estimate_size(mips[i]);
+		size_t size = tga_estimate_size(mips[i], 0);
 		assert_int_not_equal(0, size);
 		sptr_t buf = sptr_xmalloc(size);
 		tga_write(buf, mips[i]);
@@ -74,7 +74,7 @@ void test_export_from_dk(void **state)
 	for (i = 0; i < MIP_LEVELS_DK; i++) {
 		memset(&fname_buf[0], 0, 256);
 		sprintf(&fname_buf[0], "out.test_export_from_dk-mip-%d.tga%c", i, '\0');
-		size_t size = tga_estimate_size(mips[i]);
+		size_t size = tga_estimate_size(mips[i], 0);
 		assert_int_not_equal(0, size);
 		sptr_t buf = sptr_xmalloc(size);
 		tga_write(buf, mips[i]);


### PR DESCRIPTION
I think having both of these features is useful.

- CMake works good across platforms (I use it Windows and Steam Deck)
- Palette Expansion is a special flag so that e.g. if you convert a wal file to a tga file, you get 32 bit colors according to the palette

I use palette expansion to convert Daikatana resources in one go.

Please let me know if you want this PR to be split.